### PR TITLE
Bugfix/readme logo

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,4 +1,4 @@
-.. image:: https://sonos.github.io/pyFLAC/assets/logo-black.png
+.. image:: https://github.com/sonos/pyFLAC/assets/logo-black.png
     :target: https://pyflac.readthedocs.io
 
 .. image:: https://github.com/sonos/pyFLAC/actions/workflows/lint.yml/badge.svg

--- a/README.rst
+++ b/README.rst
@@ -1,4 +1,4 @@
-.. image:: https://github.com/sonos/pyFLAC/assets/logo-black.png
+.. image:: https://raw.githubusercontent.com/sonos/pyFLAC/develop/assets/logo-black.png
     :target: https://pyflac.readthedocs.io
 
 .. image:: https://github.com/sonos/pyFLAC/actions/workflows/lint.yml/badge.svg


### PR DESCRIPTION
Changed logo url in README.rst to https://raw.githubusercontent.com/sonos/pyFLAC/develop/assets/logo-black.png
Tested on MacOS Chrome, and MacOS + iOS Safari