### PR TITLE
Fix deadlock in _read_callback()

### DIFF
--- a/pyflac/decoder.py
+++ b/pyflac/decoder.py
@@ -315,20 +315,19 @@ def _read_callback(_decoder,
     """
     decoder = _ffi.from_handle(client_data)
 
-    while len(decoder._buffer) == 0 and not decoder._error:
-
-        if decoder._done:
-            # ----------------------------------------------------------
-            # The end of the stream has been instructed by a call to
-            # finish.
-            # ----------------------------------------------------------
-            num_bytes[0] = 0
-            return _lib.FLAC__STREAM_DECODER_READ_STATUS_END_OF_STREAM
-
+    while not (decoder._error or decoder._done) and len(decoder._buffer) == 0:
         # ----------------------------------------------------------
         # Wait until there is something in the buffer
         # ----------------------------------------------------------
         time.sleep(0.01)
+
+    if decoder._done:
+        # ----------------------------------------------------------
+        # The end of the stream has been instructed by a call to
+        # finish.
+        # ----------------------------------------------------------
+        num_bytes[0] = 0
+        return _lib.FLAC__STREAM_DECODER_READ_STATUS_END_OF_STREAM
 
     if decoder._error:
         # ----------------------------------------------------------

--- a/pyflac/decoder.py
+++ b/pyflac/decoder.py
@@ -321,6 +321,13 @@ def _read_callback(_decoder,
         # ----------------------------------------------------------
         time.sleep(0.01)
 
+    if decoder._error:
+        # ----------------------------------------------------------
+        # If an error has been issued via the error callback, then
+        # abort the processing of the stream.
+        # ----------------------------------------------------------
+        return _lib.FLAC__STREAM_DECODER_READ_STATUS_ABORT
+
     if decoder._done:
         # ----------------------------------------------------------
         # The end of the stream has been instructed by a call to
@@ -328,13 +335,6 @@ def _read_callback(_decoder,
         # ----------------------------------------------------------
         num_bytes[0] = 0
         return _lib.FLAC__STREAM_DECODER_READ_STATUS_END_OF_STREAM
-
-    if decoder._error:
-        # ----------------------------------------------------------
-        # If an error has been issued via the error callback, then
-        # abort the processing of the stream.
-        # ----------------------------------------------------------
-        return _lib.FLAC__STREAM_DECODER_READ_STATUS_ABORT
 
     maximum_bytes = int(num_bytes[0])
 

--- a/pyflac/decoder.py
+++ b/pyflac/decoder.py
@@ -314,6 +314,22 @@ def _read_callback(_decoder,
     If an exception is raised here, the abort status is returned.
     """
     decoder = _ffi.from_handle(client_data)
+
+    while len(decoder._buffer) == 0 and not decoder._error:
+
+        if decoder._done:
+            # ----------------------------------------------------------
+            # The end of the stream has been instructed by a call to
+            # finish.
+            # ----------------------------------------------------------
+            num_bytes[0] = 0
+            return _lib.FLAC__STREAM_DECODER_READ_STATUS_END_OF_STREAM
+
+        # ----------------------------------------------------------
+        # Wait until there is something in the buffer
+        # ----------------------------------------------------------
+        time.sleep(0.01)
+
     if decoder._error:
         # ----------------------------------------------------------
         # If an error has been issued via the error callback, then
@@ -321,20 +337,7 @@ def _read_callback(_decoder,
         # ----------------------------------------------------------
         return _lib.FLAC__STREAM_DECODER_READ_STATUS_ABORT
 
-    if decoder._done:
-        # ----------------------------------------------------------
-        # The end of the stream has been instructed by a call to
-        # finish.
-        # ----------------------------------------------------------
-        num_bytes[0] = 0
-        return _lib.FLAC__STREAM_DECODER_READ_STATUS_END_OF_STREAM
-
     maximum_bytes = int(num_bytes[0])
-    while len(decoder._buffer) == 0:
-        # ----------------------------------------------------------
-        # Wait until there is something in the buffer
-        # ----------------------------------------------------------
-        time.sleep(0.01)
 
     # --------------------------------------------------------------
     # Ensure only the maximum bytes or less is taken from


### PR DESCRIPTION
Re-ordered some state checking to avoid deadlock in the event that the buffer runs dry before finish() is called (in which case the original code would spin forever waiting for more data in the buffer, returning to the caller after a 3-second timeout but leaving the background thread spinning forever).

This also likely fixes a second, unrelated bug by allowing any buffered data to be processed before closing as opposed to truncating it immediately when finish() is called.

**_I have not tested this change personally because I am not using the library, do not have virtualenv or tox set up, etc.  I fixed it for a friend who reports that it fixed the bug.  If you are set up with all the tools to test this properly, please do?_**
