### PR TITLE
Fix bug in the shutdown behaviour of the decoder

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,7 +14,7 @@ jobs:
   flake8:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Lint the Python code
         uses: TrueBrain/actions-flake8@master
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,22 +15,22 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Install dependencies
         run: |
           sudo apt-get update -y
           sudo apt-get install libsndfile1
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install coverage
+          pip install coverage setuptools
       - name: Run tests
         run: coverage run setup.py test
       - name: Run coveralls
@@ -42,9 +42,9 @@ jobs:
   macos:
     runs-on: macos-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: 3.11
       - name: Install dependencies
@@ -58,7 +58,7 @@ jobs:
   windows:
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: recursive
       - name: Check install

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,9 +3,11 @@ pyFLAC Changelog
 
 **v3.0.0**
 
-* Fixed bug in the shutdown behaviour of the decoder (see #22 and #23).
+* Fixed bug in the shutdown behaviour of the `StreamDecoder` (see #22 and #23).
 * Automatically detect bit depth of input data in the `FileEncoder`, and
   raise an error if not 16-bit or 32-bit PCM (see #24).
+* Added a new `OneShotDecoder` to decode a buffer of FLAC data in a single
+  blocking operation, without the use of threads. Courtesy of @GOAE.
 
 **v2.2.0**
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,10 @@
 pyFLAC Changelog
 ----------------
 
+**v2.3.0**
+
+* Fixed bug in the shutdown behaviour of the decoder (see #22 and #23).
+
 **v2.2.0**
 
 * Updated FLAC library to v1.4.3.

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,9 +1,11 @@
 pyFLAC Changelog
 ----------------
 
-**v2.3.0**
+**v3.0.0**
 
 * Fixed bug in the shutdown behaviour of the decoder (see #22 and #23).
+* Automatically detect bit depth of input data in the `FileEncoder`, and
+  raise an error if not 16-bit or 32-bit PCM (see #24).
 
 **v2.2.0**
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -68,6 +68,8 @@ data directly from a file or process in real-time.
    :undoc-members:
    :inherited-members:
 
+.. autoclass:: pyflac.OneShotDecoder
+
 State
 -----
 

--- a/examples/passthrough.py
+++ b/examples/passthrough.py
@@ -29,7 +29,16 @@ class Passthrough:
         self.idx = 0
         self.total_bytes = 0
         self.queue = queue.SimpleQueue()
-        self.data, self.sr = sf.read(args.input_file, dtype='int16', always_2d=True)
+
+        info = sf.info(str(args.input_file))
+        if info.subtype == 'PCM_16':
+            dtype = 'int16'
+        elif info.subtype == 'PCM_32':
+            dtype = 'int32'
+        else:
+            raise ValueError(f'WAV input data type must be either PCM_16 or PCM_32: Got {info.subtype}')
+
+        self.data, self.sr = sf.read(args.input_file, dtype=dtype, always_2d=True)
 
         self.encoder = pyflac.StreamEncoder(
             write_callback=self.encoder_callback,

--- a/pyflac/__init__.py
+++ b/pyflac/__init__.py
@@ -4,13 +4,13 @@
 #
 #  pyFLAC
 #
-#  Copyright (c) 2020-2021, Sonos, Inc.
+#  Copyright (c) 2020-2024, Sonos, Inc.
 #  All rights reserved.
 #
 # ------------------------------------------------------------------------------
 
 __title__ = 'pyFLAC'
-__version__ = '2.2.0'
+__version__ = '3.0.0'
 __all__ = [
     'StreamEncoder',
     'FileEncoder',
@@ -19,6 +19,7 @@ __all__ = [
     'EncoderProcessException',
     'StreamDecoder',
     'FileDecoder',
+    'OneShotDecoder',
     'DecoderState',
     'DecoderInitException',
     'DecoderProcessException'
@@ -55,6 +56,7 @@ from .encoder import (
 from .decoder import (
     StreamDecoder,
     FileDecoder,
+    OneShotDecoder,
     DecoderState,
     DecoderInitException,
     DecoderProcessException

--- a/pyflac/__main__.py
+++ b/pyflac/__main__.py
@@ -27,7 +27,6 @@ def get_args():
     parser.add_argument('-c', '--compression-level', type=int, choices=range(0, 9), default=5,
                         help='0 is the fastest compression, 5 is the default, 8 is the highest compression')
     parser.add_argument('-b', '--block-size', type=int, default=0, help='The block size')
-    parser.add_argument('-d', '--dtype', default='int16', help='The encoded data type (int16 or int32)')
     parser.add_argument('-v', '--verify', action='store_false', default=True, help='Verify the compressed data')
     args = parser.parse_args()
     return args
@@ -45,7 +44,6 @@ def main():
             input_file=args.input_file,
             output_file=args.output_file,
             blocksize=args.block_size,
-            dtype=args.dtype,
             compression_level=args.compression_level,
             verify=args.verify
         )

--- a/pyflac/decoder.py
+++ b/pyflac/decoder.py
@@ -93,7 +93,8 @@ class _Decoder:
         Flushes the decoding buffer, releases resources, resets the decoder
         settings to their defaults, and returns the decoder state to `DecoderState.UNINITIALIZED`.
 
-        A well behaved program should always call this at the end.
+        A well behaved program should always call this at the end, otherwise the processing
+        thread will be left running, awaiting more data.
         """
         _lib.FLAC__stream_decoder_finish(self._decoder)
 

--- a/pyflac/decoder.py
+++ b/pyflac/decoder.py
@@ -4,7 +4,7 @@
 #
 #  pyFLAC decoder
 #
-#  Copyright (c) 2020-2021, Sonos, Inc.
+#  Copyright (c) 2020-2024, Sonos, Inc.
 #  All rights reserved.
 #
 # ------------------------------------------------------------------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pyFLAC"
-version = "2.2.0"
+version = "2.3.0"
 description = "A Python wrapper for libFLAC"
 readme = "README.rst"
 authors = [{ name = "Joe Todd", email = "joe.todd@sonos.com" }]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 #
 #  pyFLAC
 #
-#  Copyright (c) 2020-2023, Sonos, Inc.
+#  Copyright (c) 2020-2024, Sonos, Inc.
 #  All rights reserved.
 #
 # ------------------------------------------------------------------------------
@@ -12,7 +12,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pyFLAC"
-version = "2.3.0"
+version = "3.0.0"
 description = "A Python wrapper for libFLAC"
 readme = "README.rst"
 authors = [{ name = "Joe Todd", email = "joe.todd@sonos.com" }]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ classifiers = [
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Topic :: Multimedia :: Sound/Audio",
 ]
 dependencies = ["cffi>=1.4.0", "numpy>=1.22", "SoundFile>=0.11"]

--- a/tests/test_decoder.py
+++ b/tests/test_decoder.py
@@ -4,7 +4,7 @@
 #
 #  pyFLAC decoder test suite
 #
-#  Copyright (c) 2020-2021, Sonos, Inc.
+#  Copyright (c) 2020-2024, Sonos, Inc.
 #  All rights reserved.
 #
 # ------------------------------------------------------------------------------

--- a/tests/test_decoder.py
+++ b/tests/test_decoder.py
@@ -20,6 +20,7 @@ from pyflac.decoder import _Decoder
 from pyflac import (
     FileDecoder,
     StreamDecoder,
+    OneShotDecoder,
     DecoderState,
     DecoderInitException,
     DecoderProcessException
@@ -148,6 +149,32 @@ class TestFileDecoder(unittest.TestCase):
         self.default_kwargs['output_file'] = pathlib.Path(self.temp_file.name)
         self.decoder = FileDecoder(**self.default_kwargs)
         self.assertIsNotNone(self.decoder.process())
+
+
+class TestOneShotDecoder(unittest.TestCase):
+    """
+    Test suite for the one-shot decoder class.
+    """
+    def setUp(self):
+        self.decoder = None
+        self.write_callback_called = False
+        self.tests_path = pathlib.Path(__file__).parent.absolute()
+
+    def _write_callback(self, data, rate, channels, samples):
+        assert isinstance(data, np.ndarray)
+        assert isinstance(rate, int)
+        assert isinstance(channels, int)
+        assert isinstance(samples, int)
+        self.write_callback_called = True
+
+    def test_process(self):
+        """ Test that FLAC data can be decoded """
+        test_path = self.tests_path / 'data/stereo.flac'
+        with open(test_path, 'rb') as flac:
+            test_data = flac.read()
+
+        self.decoder = OneShotDecoder(write_callback=self._write_callback, buffer=test_data)
+        self.assertTrue(self.write_callback_called)
 
 
 if __name__ == '__main__':

--- a/tests/test_decoder.py
+++ b/tests/test_decoder.py
@@ -76,6 +76,7 @@ class TestStreamDecoder(unittest.TestCase):
         self.decoder.process(test_data)
         self.decoder.finish()
         self.assertTrue(self.write_callback_called)
+        self.assertFalse(self.decoder._thread.is_alive())
 
     def test_process_blocks(self):
         """ Test that FLAC data can be decoded in blocks """

--- a/tests/test_encoder.py
+++ b/tests/test_encoder.py
@@ -4,7 +4,7 @@
 #
 #  pyFLAC encoder test suite
 #
-#  Copyright (c) 2020-2021, Sonos, Inc.
+#  Copyright (c) 2020-2024, Sonos, Inc.
 #  All rights reserved.
 #
 # ------------------------------------------------------------------------------
@@ -237,12 +237,6 @@ class TestFileEncoder(unittest.TestCase):
         with self.assertRaisesRegex(EncoderInitException, 'FLAC__STREAM_ENCODER_INIT_STATUS_INVALID_BLOCK_SIZE'):
             self.encoder._init()
 
-    def test_invalid_dtype(self):
-        """ Test than an exception is raised if given an invalid dtype """
-        self.default_kwargs['dtype'] = 'int24'
-        with self.assertRaisesRegex(ValueError, 'FLAC encoding data type must be either int16 or int32'):
-            self.encoder = FileEncoder(**self.default_kwargs)
-
     def test_blocksize_streamable_subset(self):
         """ Test that an exception is raised if blocksize is outside the streamable subset """
         self.default_kwargs['blocksize'] = 65535
@@ -291,7 +285,6 @@ class TestFileEncoder(unittest.TestCase):
         test_path = pathlib.Path(__file__).parent.absolute() / 'data/32bit.wav'
         self.default_kwargs['input_file'] = test_path
         self.default_kwargs['output_file'] = pathlib.Path(self.temp_file.name)
-        self.default_kwargs['dtype'] = 'int32'
         self.encoder = FileEncoder(**self.default_kwargs)
         self.encoder.process()
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py38, py39, py310, py311
+envlist = py38, py39, py310, py311, py312
 
 [testenv]
 deps = pytest==7.4.0


### PR DESCRIPTION
- This fixes a bug where decoder threads are left hanging waiting for more data to process, when the stream has already finished.
- Switching polling for thread signalling with `Event`s, and also added a `Lock` when reading/writing the buffer.
- I also updated the `FileEncoder` to automatically detect the bit depth of the input file, and use this for encoding. An error is raised if it is not 16 or 32 bit PCM. Since this made the `dtype` variable redundant, I updated the version to v3.
- Added @GOAE 's suggestion of a `OneShotDecoder` for anyone that just wants to decode a buffer once, rather than in real time.
- Added official support for Python3.12

Closes: #22
Closes: #23 
Closes: #24 